### PR TITLE
投稿詳細ページと投稿編集ページのバグを修正

### DIFF
--- a/src/pages/createPost.tsx
+++ b/src/pages/createPost.tsx
@@ -25,18 +25,18 @@ export default function CreatePost() {
     const content: string = (data.get('content') ?? '').toString()
 
     // postsに投稿を作成
-    await addDoc(collection(db, "posts"), {
+    await addDoc(collection(db, 'posts'), {
       title: title,
       content: content,
-      poster: "yet"
+      poster: 'yet'
     })
-    const q = await query(collection(db, "posts"), where("poster", "==", "yet"))
+    const q = await query(collection(db, 'posts'), where('poster', '==', 'yet'))
     const querySnapshot = await getDocs(q)
-    let postId = ""
+    let postId = ''
     querySnapshot.forEach((doc) => {
       postId = doc.id
     })
-    const updateRef = doc(db, "posts", postId)
+    const updateRef = doc(db, 'posts', postId)
     await updateDoc(updateRef, {
       poster: uid
     })

--- a/src/pages/createPost.tsx
+++ b/src/pages/createPost.tsx
@@ -1,10 +1,9 @@
-import { doc, getDoc, updateDoc } from 'firebase/firestore'
+import { addDoc, collection, doc, getDoc, getDocs, query, updateDoc, where } from 'firebase/firestore'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useRecoilValue } from 'recoil'
 import { isLoginState, uidState } from '../atoms'
 import { db } from '../firebaseConfig'
-import { getUniqueStr } from '../uniqueStr'
 
 export default function CreatePost() {
   const router = useRouter()
@@ -25,13 +24,31 @@ export default function CreatePost() {
     const title: string = (data.get('title') ?? '').toString()
     const content: string = (data.get('content') ?? '').toString()
 
+    // postsに投稿を作成
+    await addDoc(collection(db, "posts"), {
+      title: title,
+      content: content,
+      poster: "yet"
+    })
+    const q = await query(collection(db, "posts"), where("poster", "==", "yet"))
+    const querySnapshot = await getDocs(q)
+    let postId = ""
+    querySnapshot.forEach((doc) => {
+      postId = doc.id
+    })
+    const updateRef = doc(db, "posts", postId)
+    await updateDoc(updateRef, {
+      poster: uid
+    })
+
+    // usersに投稿を作成
     const userDocData = await (await getDoc(doc(db, 'users', uid))).data()
     const posts = userDocData.posts
     const postNum: number = userDocData.postNum
     const updatedPosts =
       postNum === 0
-        ? [{ id: getUniqueStr(), title: title, content: content }]
-        : [...posts, { id: getUniqueStr(), title: title, content: content }]
+        ? [{ id: postId, title: title, content: content }]
+        : [...posts, { id: postId, title: title, content: content }]
     const updatedPostNum: number = postNum + 1
 
     await updateDoc(doc(db, 'users', uid), {

--- a/src/pages/posts/[id]/edit.tsx
+++ b/src/pages/posts/[id]/edit.tsx
@@ -13,11 +13,25 @@ export default function PostsIdEdit() {
   const isLogin = useRecoilValue(isLoginState)
   const uid = useRecoilValue(uidState)
 
-  useEffect(() => {
-    if (isLogin === false) {
-      router.push("/")
+  const [poster, setPoster] = useState(uid)
+
+  const getPoster = async () => {
+    // urlを直打ちした場合、初回レンダリング時にpostIdは[id]/editとなるため
+    if (postId.length === 20) {
+      const postRef = doc(db, "posts", postId)
+      const postSnap = await getDoc(postRef)
+      if (postSnap.exists()) {
+        setPoster(postSnap.data().poster)
+      }
     }
-  }, [isLogin])
+  }
+  getPoster()
+
+  useEffect(() => {
+    if ((isLogin === false) || (poster !== uid)) {
+      router.push(`/posts/${postId}`)
+    }
+  }, [isLogin, poster])
 
   const [post, setPost] = useState({id: "", title: "", content: ""})
   const [posts, setPosts] = useState([{id: "", title: "", content: ""}])

--- a/src/pages/posts/[id]/edit.tsx
+++ b/src/pages/posts/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import { doc, getDoc, updateDoc } from "firebase/firestore"
+import { deleteDoc, doc, getDoc, updateDoc } from "firebase/firestore"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { useEffect, useState } from "react"
@@ -8,6 +8,7 @@ import { db } from "../../../firebaseConfig"
 
 export default function PostsIdEdit() {
   const router = useRouter()
+  const postId = router.asPath.slice(7, 27)
 
   const isLogin = useRecoilValue(isLoginState)
   const uid = useRecoilValue(uidState)
@@ -23,7 +24,6 @@ export default function PostsIdEdit() {
   const [postNum, setPostNum] = useState(0)
 
   const getUserPost = async () => {
-    const postId = router.asPath.slice(7, 21)
     const userRef = doc(db, "users", uid)
     const userSnap = await getDoc(userRef)
     if (userSnap.exists() && post.id === "") {
@@ -45,6 +45,10 @@ export default function PostsIdEdit() {
     await updateDoc(doc(db, "users", uid), {
       "posts": newPosts
     })
+    await updateDoc(doc(db, "posts", postId), {
+      "title": post.title,
+      "content": post.content
+    })
     router.push(`/posts/${post.id}`)
   }
 
@@ -62,7 +66,7 @@ export default function PostsIdEdit() {
         "postNum": postNum - 1
       })
     }
-
+    await deleteDoc(doc(db, "posts", postId))
     router.push("/posts")
   }
 

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -1,27 +1,20 @@
 import { doc, getDoc } from "firebase/firestore"
 import Link from "next/link"
 import { useRouter } from "next/router"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useRecoilValue } from "recoil"
-import { isLoginState, uidState } from "../../../atoms"
+import { uidState } from "../../../atoms"
 import { db } from "../../../firebaseConfig"
 
 export default function PostsId() {
   const router = useRouter()
+  const postId = router.asPath.slice(7)
 
-  const isLogin = useRecoilValue(isLoginState)
   const uid = useRecoilValue(uidState)
 
-  useEffect(() => {
-    if (isLogin === false) {
-      router.push("/")
-    }
-  }, [isLogin])
-
-  const [post, setPost] = useState({id: "", title: "", content: ""})
+  const [post, setPost] = useState({poster: "", title: "", content: ""})
 
   const getPost = async () => {
-    const postId = router.asPath.slice(7)
     const postRef = doc(db, "posts", postId)
     const postSnap = await getDoc(postRef)
     if (postSnap.exists()) {
@@ -34,12 +27,15 @@ export default function PostsId() {
     <div>
       <p>投稿詳細ページ</p>
       <br />
-      <p>{post.id}</p>
+      <p>{postId}</p>
       <p>{post.title}</p>
       <p>{post.content}</p>
-      <Link href={`/posts/${post.id}/edit`}>
-        <p>投稿編集ページへ</p>
-      </Link>
+      <p>{post.poster}</p>
+      {post.poster === uid && (
+        <Link href={`/posts/${postId}/edit`}>
+          <p>投稿編集ページへ</p>
+        </Link>
+      ) }
     </div>
   )
 }

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -19,24 +19,16 @@ export default function PostsId() {
   }, [isLogin])
 
   const [post, setPost] = useState({id: "", title: "", content: ""})
-  const [posts, setPosts] = useState([{id: "", title: "", content: ""}])
-  const [postNum, setPostNum] = useState(0)
 
-  const getUserPost = async () => {
+  const getPost = async () => {
     const postId = router.asPath.slice(7)
-    const userRef = doc(db, "users", uid)
-    const userSnap = await getDoc(userRef)
-    if (userSnap.exists()) {
-      setPosts(userSnap.data().posts)
-      setPostNum(userSnap.data().postNum)
-      for (let i = 0; i < postNum; i++) {
-        if (posts[i].id === postId) {
-          setPost(posts[i])
-        }
-      }
+    const postRef = doc(db, "posts", postId)
+    const postSnap = await getDoc(postRef)
+    if (postSnap.exists()) {
+      setPost(postSnap.data())
     }
   }
-  getUserPost()
+  getPost()
 
   return (
     <div>

--- a/src/uniqueStr.tsx
+++ b/src/uniqueStr.tsx
@@ -1,8 +1,0 @@
-export function getUniqueStr(myStrong?: number): string {
-  let strong = 1000;
-  if (myStrong) strong = myStrong;
-  return (
-    new Date().getTime().toString(16) +
-    Math.floor(strong * Math.random()).toString(16)
-  );
-}


### PR DESCRIPTION
## IssueのURL
closes #30

## 対応内容・対応背景・妥協点
投稿詳細ページと投稿編集ページのバグを修正

## やったこと
新規投稿時にpostsとusersどちらにも投稿を作成する
投稿詳細が自分の投稿でないと見れないバグを修正
投稿者とログインユーザーが一致した場合のみ、投稿編集ページへのリンクが表示されるようにする
投稿の編集・削除時に、postsでも編集・削除されるように変更
投稿編集ページでは、投稿者とログインユーザーが一致しないと入れないように変更