### PR TITLE
画像登録の機能実装

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['firebasestorage.googleapis.com'],
+  },
 }
 
 module.exports = nextConfig

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 export const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -16,3 +17,4 @@ initializeApp(firebaseConfig);
 
 export const auth = getAuth()
 export const db = getFirestore()
+export const storage = getStorage()

--- a/src/pages/createPost.tsx
+++ b/src/pages/createPost.tsx
@@ -43,17 +43,17 @@ export default function CreatePost() {
     })
 
     // 画像をStorageに保存し、URLをpostsに作成
-    let imageUrl = ""
-    const image = document.getElementById("image") as HTMLInputElement
-    if (image.value !== "") {
+    let imageUrl = ''
+    const image = document.getElementById('image') as HTMLInputElement
+    if (image.value !== '') {
       await uploadBytes(ref(storage, `postImages/${postId}`), image.files[0])
       const pathReference = ref(storage, `postImages/${postId}`)
-      await getDownloadURL(pathReference)
-      .then((url) => {
+      await getDownloadURL(pathReference).then((url) => {
         imageUrl = url
       })
     } else {
-      imageUrl = "https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e"
+      imageUrl =
+        'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e'
     }
     await updateDoc(updateRef, {
       image: imageUrl

--- a/src/pages/createPost.tsx
+++ b/src/pages/createPost.tsx
@@ -69,6 +69,9 @@ export default function CreatePost() {
         <input name="content" className="bg-code-blue" />
         <br />
         <br />
+        <input id="image" type="file" />
+        <br />
+        <br />
         <button className="bg-code-green">新規投稿</button>
       </form>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { collection, onSnapshot, query } from 'firebase/firestore'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { db } from '../firebaseConfig'
@@ -19,7 +20,7 @@ export default function Home() {
     {
       uid: '',
       name: '',
-      image:'',
+      image: '',
       languages: [],
       hobbies: [],
       postNum: 0,
@@ -399,7 +400,7 @@ export default function Home() {
             ) {
               return (
                 <div key={index} className="bg-black-light mb-[10px]">
-                  <img src={user.image} className="w-[100px]"/>
+                  <Image src={user.image} alt="ユーザー画像" width="100px" height="100px" />
                   <p className="text-code-white">{user.name}</p>
                   <p className="text-code-white">{user.languages}</p>
                   <p className="text-code-white">{user.hobbies}</p>
@@ -411,6 +412,7 @@ export default function Home() {
                   {user.postNum >= 1 && (
                     <div>
                       <p className="text-code-white">{user.posts[0].title}</p>
+                      <Image src={user.posts[0].image} alt="投稿サムネイル1" width="200px" height="100px" />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>
@@ -419,6 +421,7 @@ export default function Home() {
                   {user.postNum >= 2 && (
                     <div>
                       <p className="text-code-white">{user.posts[1].title}</p>
+                      <Image src={user.posts[1].image} alt="投稿サムネイル2" width="200px" height="100px" />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>
@@ -427,6 +430,7 @@ export default function Home() {
                   {user.postNum >= 3 && (
                     <div>
                       <p className="text-code-white">{user.posts[2].title}</p>
+                      <Image src={user.posts[2].image} alt="投稿サムネイル3" width="200px" height="100px" />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -400,7 +400,16 @@ export default function Home() {
             ) {
               return (
                 <div key={index} className="bg-black-light mb-[10px]">
-                  <Image src={user.image} alt="ユーザー画像" width="100px" height="100px" />
+                  <Image
+                    src={
+                      user.image
+                        ? user.image
+                        : 'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/userImages%2Finit.jpg?alt=media&token=69a50ddd-5912-4415-91cb-1cdb1fdf6d3f'
+                    }
+                    alt="ユーザー画像"
+                    width="100px"
+                    height="100px"
+                  />
                   <p className="text-code-white">{user.name}</p>
                   <p className="text-code-white">{user.languages}</p>
                   <p className="text-code-white">{user.hobbies}</p>
@@ -412,7 +421,16 @@ export default function Home() {
                   {user.postNum >= 1 && (
                     <div>
                       <p className="text-code-white">{user.posts[0].title}</p>
-                      <Image src={user.posts[0].image} alt="投稿サムネイル1" width="200px" height="100px" />
+                      <Image
+                        src={
+                          user.posts[0].image
+                            ? user.posts[0].image
+                            : 'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e'
+                        }
+                        alt="投稿サムネイル1"
+                        width="200px"
+                        height="100px"
+                      />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>
@@ -421,7 +439,16 @@ export default function Home() {
                   {user.postNum >= 2 && (
                     <div>
                       <p className="text-code-white">{user.posts[1].title}</p>
-                      <Image src={user.posts[1].image} alt="投稿サムネイル2" width="200px" height="100px" />
+                      <Image
+                        src={
+                          user.posts[1].image
+                            ? user.posts[1].image
+                            : 'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e'
+                        }
+                        alt="投稿サムネイル2"
+                        width="200px"
+                        height="100px"
+                      />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>
@@ -430,7 +457,16 @@ export default function Home() {
                   {user.postNum >= 3 && (
                     <div>
                       <p className="text-code-white">{user.posts[2].title}</p>
-                      <Image src={user.posts[2].image} alt="投稿サムネイル3" width="200px" height="100px" />
+                      <Image
+                        src={
+                          user.posts[2].image
+                            ? user.posts[2].image
+                            : 'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e'
+                        }
+                        alt="投稿サムネイル3"
+                        width="200px"
+                        height="100px"
+                      />
                       <Link href="/">
                         <a className="text-code-blue">もっと詳しく</a>
                       </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ export default function Home() {
     {
       uid: '',
       name: '',
+      image:'',
       languages: [],
       hobbies: [],
       postNum: 0,
@@ -40,6 +41,7 @@ export default function Home() {
         querySnapshot.docs.map((user) => ({
           uid: user.data().uid,
           name: user.data().name,
+          image: user.data().image,
           languages: user.data().languages,
           hobbies: user.data().hobbies,
           postNum: user.data().postNum,
@@ -397,6 +399,7 @@ export default function Home() {
             ) {
               return (
                 <div key={index} className="bg-black-light mb-[10px]">
+                  <img src={user.image} className="w-[100px]"/>
                   <p className="text-code-white">{user.name}</p>
                   <p className="text-code-white">{user.languages}</p>
                   <p className="text-code-white">{user.hobbies}</p>

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -12,7 +12,7 @@ export default function PostsId() {
 
   const uid = useRecoilValue(uidState)
 
-  const [post, setPost] = useState({poster: "", title: "", content: ""})
+  const [post, setPost] = useState({poster: "", title: "", content: "", image: ""})
 
   const getPost = async () => {
     const postRef = doc(db, "posts", postId)
@@ -30,6 +30,7 @@ export default function PostsId() {
       <p>{postId}</p>
       <p>{post.title}</p>
       <p>{post.content}</p>
+      <img src={post.image} className="w-[300px]"/>
       <p>{post.poster}</p>
       {post.poster === uid && (
         <Link href={`/posts/${postId}/edit`}>

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -41,6 +41,7 @@ export default function Posts() {
       {postNum >= 1 && posts.map((post: any, index: number) => (
         <div key={index}>
           <p>ID：　{post.id}</p>
+          <img src={post.image} className="w-[300px]"/>
           <p>タイトル： {post.title}</p>
           <p>内容：　{post.content}</p>
           <Link href={`/posts/${post.id}`}>

--- a/src/pages/setting/profile/edit.tsx
+++ b/src/pages/setting/profile/edit.tsx
@@ -92,8 +92,8 @@ export default function ProfileEdit() {
   const clickEditDone = async () => {
     const image = document.getElementById("image") as HTMLInputElement
     if (image.value !== "") {
-      await uploadBytes(ref(storage, uid), image.files[0])
-      const pathReference = ref(storage, uid)
+      await uploadBytes(ref(storage, `userImages/${uid}`), image.files[0])
+      const pathReference = ref(storage, `userImages/${uid}`)
       let imageUrl = ""
       await getDownloadURL(pathReference)
       .then((url) => {

--- a/src/pages/setting/profile/edit.tsx
+++ b/src/pages/setting/profile/edit.tsx
@@ -1,10 +1,11 @@
-import { doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { isLoginState, uidState } from "../../../atoms";
-import { db } from "../../../firebaseConfig";
+import { db, storage } from "../../../firebaseConfig";
 import { games, languages, sports, watching } from "../../../languagesAndHobbies";
 
 export default function ProfileEdit() {
@@ -21,6 +22,7 @@ export default function ProfileEdit() {
 
   const [userName, setUserName] = useState("")
   const [userEmail, setUserEmail] = useState("")
+  const [userImage, setUserImage] = useState("")
   const [userLanguages, setUserLanguages] = useState(["None"])
   const [userHobbies, setUserHobbies] = useState(["None"])
 
@@ -32,6 +34,7 @@ export default function ProfileEdit() {
     if (userSnap.exists() && userEmail !== userSnap.data().email) {
       setUserName(userSnap.data().name)
       setUserEmail(userSnap.data().email)
+      setUserImage(userSnap.data().image)
       setUserLanguages(userSnap.data().languages)
       setUserHobbies(userSnap.data().hobbies)
     }
@@ -86,13 +89,30 @@ export default function ProfileEdit() {
     }
   }
 
-  const clickEditDone = () => {
-    // チェックボックスの内容をfirestoreに反映
-    updateDoc(doc(db, "users", uid), {
-      "name": userName,
-      "languages": userLanguages,
-      "hobbies": userHobbies
-    })
+  const clickEditDone = async () => {
+    const image = document.getElementById("image") as HTMLInputElement
+    if (image.value !== "") {
+      await uploadBytes(ref(storage, uid), image.files[0])
+      const pathReference = ref(storage, uid)
+      let imageUrl = ""
+      await getDownloadURL(pathReference)
+      .then((url) => {
+        imageUrl = url
+        setUserImage(url)
+      })
+      updateDoc(doc(db, "users", uid), {
+        "name": userName,
+        "image": imageUrl,
+        "languages": userLanguages,
+        "hobbies": userHobbies
+      })
+    } else {
+      updateDoc(doc(db, "users", uid), {
+        "name": userName,
+        "languages": userLanguages,
+        "hobbies": userHobbies
+      })
+    }
   }
 
   return (
@@ -101,6 +121,11 @@ export default function ProfileEdit() {
       <br />
       <p>ユーザー名</p>
       <input value={userName} onChange={(e: any) => setUserName(e.target.value)}/>
+      <br />
+      <br />
+      <img src={userImage} className="w-[100px]" />
+      <br />
+      <input id="image" type="file" />
       <br />
       <br />
       <p>プログラミング言語</p>

--- a/src/pages/setting/profile/index.tsx
+++ b/src/pages/setting/profile/index.tsx
@@ -21,6 +21,7 @@ export default function Profile() {
 
   const [userName, setUserName] = useState("")
   const [userEmail, setUserEmail] = useState("")
+  const [userImage, setUserImage] = useState("")
   const [userLanguages, setUserLanguages] = useState(["None"])
   const [userHobbies, setUserHobbies] = useState(["None"])
 
@@ -33,6 +34,7 @@ export default function Profile() {
       if (userSnap.exists()) {
         setUserName(userSnap.data().name)
         setUserEmail(userSnap.data().email)
+        setUserImage(userSnap.data().image)
         setUserLanguages(userSnap.data().languages)
         setUserHobbies(userSnap.data().hobbies)
       }
@@ -59,6 +61,7 @@ export default function Profile() {
   return (
     <div>
       <p>プロフィール</p>
+      <img src={userImage} className="w-[100px]" />
       <p>ユーザーID: {uid}</p>
       <p>ユーザー名: {userName}</p>
       <p>メールアドレス: {userEmail}</p>

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -77,7 +77,8 @@ export default function SignUp() {
         languages: ['None'],
         name: userName,
         email: email,
-        image: "https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/userImages%2Finit.jpg?alt=media&token=69a50ddd-5912-4415-91cb-1cdb1fdf6d3f",
+        image:
+          'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/userImages%2Finit.jpg?alt=media&token=69a50ddd-5912-4415-91cb-1cdb1fdf6d3f',
         postNum: 0,
         posts: [{}]
       })

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -77,6 +77,7 @@ export default function SignUp() {
         languages: ['None'],
         name: userName,
         email: email,
+        image: "https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/init.jpg?alt=media&token=a1e1b36c-8efa-4305-8369-2ec3b34681b8",
         postNum: 0,
         posts: [{}]
       })

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -77,7 +77,7 @@ export default function SignUp() {
         languages: ['None'],
         name: userName,
         email: email,
-        image: "https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/init.jpg?alt=media&token=a1e1b36c-8efa-4305-8369-2ec3b34681b8",
+        image: "https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/userImages%2Finit.jpg?alt=media&token=69a50ddd-5912-4415-91cb-1cdb1fdf6d3f",
         postNum: 0,
         posts: [{}]
       })


### PR DESCRIPTION
## IssueのURL
closes #27

## 対応内容・対応背景・妥協点
画像登録の機能実装

## やったこと
新規ユーザー登録時に初期画像を設定
プロフィール編集ページでユーザー画像を変更できるように
投稿サムネイル画像の登録・編集機能の実装

## やってないこと・できていないこと
投稿サムネイル画像をいくつかデフォルトで用意しておく(#36)

## UI before / after
![スクリーンショット 2022-07-16 14 57 16](https://user-images.githubusercontent.com/28186588/179342099-e445e075-2ed1-4a33-b92a-46b1ad5bf473.png)

