### PR TITLE
新規登録時にメールアドレスがユーザーのものか確認するようにする

### DIFF
--- a/src/pages/setting/profile/index.tsx
+++ b/src/pages/setting/profile/index.tsx
@@ -25,6 +25,7 @@ export default function Profile() {
   const [userImage, setUserImage] = useState('')
   const [userLanguages, setUserLanguages] = useState(['None'])
   const [userHobbies, setUserHobbies] = useState(['None'])
+  const [userVerification, setUserVerification] = useState(false)
 
   const [message, setMessage] = useState('')
 
@@ -39,6 +40,7 @@ export default function Profile() {
           setUserImage(userSnap.data().image)
           setUserLanguages(userSnap.data().languages)
           setUserHobbies(userSnap.data().hobbies)
+          setUserVerification(auth.currentUser.emailVerified)
         }
       }
     }
@@ -72,6 +74,7 @@ export default function Profile() {
         <p>メールアドレス: {userEmail}</p>
         <p>プログラミング言語: {userLanguages}</p>
         <p>趣味: {userHobbies}</p>
+        <p>{userVerification ? 'メールアドレス確認済み' : 'メールアドレスが確認されていません'}</p>
         <br />
         <Link href="/posts">
           <p>投稿一覧ページへ</p>

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
 import { useEffect, useState } from 'react'
 import { auth, db } from '../firebaseConfig'
 import Link from 'next/link'
@@ -84,6 +84,10 @@ export default function SignUp() {
       })
       setIsLogin(true)
       setUid(uid)
+      await sendEmailVerification(auth.currentUser)
+       .then(() => {
+        // メールアドレス確認メールを送信した旨のポップアップを出す
+       })
     }
 
     // Firebase Authを使い、メールアドレスとパスワードを登録

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -84,10 +84,9 @@ export default function SignUp() {
       })
       setIsLogin(true)
       setUid(uid)
-      await sendEmailVerification(auth.currentUser)
-       .then(() => {
+      await sendEmailVerification(auth.currentUser).then(() => {
         // メールアドレス確認メールを送信した旨のポップアップを出す
-       })
+      })
     }
 
     // Firebase Authを使い、メールアドレスとパスワードを登録


### PR DESCRIPTION
## IssueのURL
closes #43

## 対応内容・対応背景・妥協点
新規登録時にメールアドレスがユーザーのものか確認するようにする

## やったこと
新規登録した際に確認用のメールアドレスを送る
profile/index.tsxでメールアドレスの確認をしているかの表示を出すように

## やってないこと・できていないこと
確認用のメールアドレスを送った際にTopページにポップアップを出す(#42)

## UI before / after
![スクリーンショット 2022-07-19 21 23 20](https://user-images.githubusercontent.com/28186588/179749316-0c0ce950-e86e-421a-8382-fdfb9e051240.png)