### PR TITLE
新規登録時にメールアドレスの確認のポップアップを表示

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -43,7 +43,9 @@ export const Modal = () => {
                     </div>
                     <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <Dialog.Title as="h3" className="text-lg leading-6 font-medium text-gray-900">
-                        {modalTitle !== '新規登録' ? `${modalTitle}が完了しました` : `${modalTitle}が完了しました。メールを送りましたので、メールアドレスのご確認をお願いいたします。`}
+                        {modalTitle !== '新規登録'
+                          ? `${modalTitle}が完了しました`
+                          : `${modalTitle}が完了しました。メールを送りましたので、メールアドレスのご確認をお願いいたします。`}
                       </Dialog.Title>
                     </div>
                   </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -43,7 +43,7 @@ export const Modal = () => {
                     </div>
                     <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <Dialog.Title as="h3" className="text-lg leading-6 font-medium text-gray-900">
-                        {`${modalTitle}が完了しました`}
+                        {modalTitle !== '新規登録' ? `${modalTitle}が完了しました` : `${modalTitle}が完了しました。メールを送りましたので、メールアドレスのご確認をお願いいたします。`}
                       </Dialog.Title>
                     </div>
                   </div>


### PR DESCRIPTION
## IssueのURL
closes #52

## 対応内容・対応背景・妥協点
新規登録時にメールアドレスの確認のポップアップを表示

## やったこと
メールアドレス確認のモーダルの表示

## UI before / after
![スクリーンショット 2022-07-21 18 45 01](https://user-images.githubusercontent.com/28186588/180183882-19bd2fcc-fa61-4021-9b6c-eb7b4412aa1d.png)

