### PR TITLE
新規登録後にプロフィール情報と新規投稿への動線を作る

### DIFF
--- a/src/pages/checkMail.tsx
+++ b/src/pages/checkMail.tsx
@@ -46,7 +46,7 @@ export default function CheckMail() {
       </div>
     )
   } else {
-    router.push('/newUser')
+    router.push('/newUser/profile')
     setOpen(true)
     setAction('メールアドレスの確認')
     return (

--- a/src/pages/checkMail.tsx
+++ b/src/pages/checkMail.tsx
@@ -1,0 +1,58 @@
+import { onAuthStateChanged, sendEmailVerification } from "firebase/auth"
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+import { useSetRecoilState } from "recoil"
+import { modal, modalAction } from "../atoms"
+import { auth } from "../firebaseConfig"
+
+export default function CheckMail() {
+  const router = useRouter()
+  const setOpen = useSetRecoilState(modal)
+  const setAction = useSetRecoilState(modalAction)
+  const [checkMail, setCheckMail] = useState(false)
+  const [message, setMessage] = useState('')
+
+  onAuthStateChanged(auth, (user) => {
+    if (user) {
+      setCheckMail(user.emailVerified)
+    }
+  })
+
+  const clickCheck = () => {
+    window.location.reload()
+  }
+
+  const clickSendAgain = () => {
+    sendEmailVerification(auth.currentUser)
+    .then(() => {
+      setOpen(true)
+      setAction('メールアドレスの確認メールの送信')
+    })
+    .catch((error) => {
+      setMessage(error)
+    })
+  }
+
+  if (checkMail === false) {
+    return (
+      <div>
+        <p className="text-red-600">{message}</p>
+        <p>メールアドレスの確認がされていません</p>
+        <p>メールアドレスを確認してください</p>
+        <br />
+        <button onClick={clickCheck}>メールアドレスを確認しました</button>
+        <br />
+        <button onClick={clickSendAgain}>確認メールを再度送る</button>
+      </div>
+    )
+  } else {
+    router.push('/newUser')
+    setOpen(true)
+    setAction('メールアドレスの確認')
+    return (
+      <div>
+        <p>メールアドレスが確認できました</p>
+      </div>
+    )
+  }
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -50,7 +50,7 @@ export default function Login() {
       .then((userCredential) => {
         setIsLogin(true)
         setUid(userCredential.user.uid)
-        router.push('/')
+        userCredential.user.emailVerified ? router.push('/') : router.push('/checkMail')
         setOpen(true)
         setAction('ログイン')
       })

--- a/src/pages/newUser.tsx
+++ b/src/pages/newUser.tsx
@@ -1,0 +1,7 @@
+export default function NewUser() {
+  return (
+    <div>
+      <p>新規ユーザー、ようこそ</p>
+    </div>
+  )
+}

--- a/src/pages/newUser.tsx
+++ b/src/pages/newUser.tsx
@@ -1,7 +1,0 @@
-export default function NewUser() {
-  return (
-    <div>
-      <p>新規ユーザー、ようこそ</p>
-    </div>
-  )
-}

--- a/src/pages/newUser/post.tsx
+++ b/src/pages/newUser/post.tsx
@@ -1,0 +1,168 @@
+import { addDoc, collection, doc, getDoc, getDocs, query, updateDoc, where } from 'firebase/firestore'
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { isLoginState, modal, modalAction, uidState } from '../../atoms'
+import { db, storage } from '../../firebaseConfig'
+
+export default function NewUserPost() {
+  const router = useRouter()
+
+  const isLogin = useRecoilValue(isLoginState)
+  const uid = useRecoilValue(uidState)
+  const setOpen = useSetRecoilState(modal)
+  const setAction = useSetRecoilState(modalAction)
+
+  useEffect(() => {
+    if (isLogin === false) {
+      router.push('/')
+    }
+  }, [isLogin, router])
+
+  const [selectImage, setSelectImage] = useState('choice')
+  const [choiceImage, setChoiceImage] = useState('example1')
+
+  const clickPost = async (e: any) => {
+    e.preventDefault()
+    const data = new FormData(e.currentTarget)
+
+    const title: string = (data.get('title') ?? '').toString()
+    const content: string = (data.get('content') ?? '').toString()
+
+    // postsに投稿を作成
+    await addDoc(collection(db, 'posts'), {
+      title: title,
+      content: content,
+      poster: 'yet'
+    })
+    const q = await query(collection(db, 'posts'), where('poster', '==', 'yet'))
+    const querySnapshot = await getDocs(q)
+    let postId = ''
+    querySnapshot.forEach((doc) => {
+      postId = doc.id
+    })
+    const updateRef = doc(db, 'posts', postId)
+    await updateDoc(updateRef, {
+      poster: uid
+    })
+
+    // 画像をStorageに保存し、URLをpostsに作成
+    let imageUrl = ''
+    if (selectImage === 'choice') {
+      imageUrl = document.getElementById(choiceImage).src
+    } else {
+      const image = document.getElementById('image') as HTMLInputElement
+      if (image.value !== '') {
+        await uploadBytes(ref(storage, `postImages/${postId}`), image.files[0])
+        const pathReference = ref(storage, `postImages/${postId}`)
+        await getDownloadURL(pathReference).then((url) => {
+          imageUrl = url
+        })
+      } else {
+        imageUrl =
+          'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2FpostInit.jpg?alt=media&token=b468ee38-405a-4044-a9f5-d55a38ff222e'
+      }
+    }
+    await updateDoc(updateRef, {
+      image: imageUrl
+    })
+
+    // usersに投稿を作成
+    const userDocData = await (await getDoc(doc(db, 'users', uid))).data()
+    const posts = userDocData.posts
+    const postNum: number = userDocData.postNum
+    const updatedPosts =
+      postNum === 0
+        ? [{ id: postId, title: title, content: content, image: imageUrl }]
+        : [...posts, { id: postId, title: title, content: content, image: imageUrl }]
+    const updatedPostNum: number = postNum + 1
+
+    await updateDoc(doc(db, 'users', uid), {
+      postNum: updatedPostNum,
+      posts: updatedPosts
+    })
+
+    router.push('/')
+    setOpen(true)
+    setAction('新規投稿')
+  }
+
+  return (
+    <div>
+      <p>投稿をしてみましょう</p>
+      <form onSubmit={(e: any) => clickPost(e)}>
+        <p>タイトル</p>
+        <input name="title" className="bg-code-blue" />
+        <p>内容</p>
+        <input name="content" className="bg-code-blue" />
+        <br />
+        <br />
+        <select
+          name="selectImage"
+          id="selectImage"
+          value={selectImage}
+          onChange={(e) => setSelectImage(e.target.value)}
+        >
+          <option value="choice">サンプル画像から選ぶ</option>
+          <option value="upload">画像をアップロードする</option>
+        </select>
+        <br />
+        <br />
+        <input id="image" type="file" disabled={selectImage === 'choice'} />
+        <br />
+        <br />
+        {selectImage === 'choice' && (
+          <div className="flex">
+            {/* eslint-disable */}
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample1.jpg?alt=media&token=6bb2265e-27fd-4153-a8f4-52fbd1e0ee0f"
+              alt="例1"
+              id="example1"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example1' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example1')}
+            />
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample2.jpg?alt=media&token=eb9e6e66-5bbe-4cca-94b5-53268bcc78d5"
+              alt="例2"
+              id="example2"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example2' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example2')}
+            />
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample3.jpg?alt=media&token=918e08bb-ac56-4ba6-aa1a-37d5dee38958"
+              alt="例3"
+              id="example3"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example3' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example3')}
+            />
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample4.jpg?alt=media&token=0fe201b0-af92-44df-9df4-961b7f8d7b36"
+              alt="例4"
+              id="example4"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example4' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example4')}
+            />
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample5.jpg?alt=media&token=3ccdfcea-10ef-42f8-baf2-c02462724e11"
+              alt="例5"
+              id="example5"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example5' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example5')}
+            />
+            <img
+              src="https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/postImages%2Fexample6.jpg?alt=media&token=ca652961-f177-4c66-88d0-87618a0d89eb"
+              alt="例6"
+              id="example6"
+              className={`w-[300px] mr-[30px] p-[5px] ${choiceImage === 'example6' ? 'bg-code-blue' : 'bg-white'}`}
+              onClick={() => setChoiceImage('example6')}
+            />
+            {/* eslint-enable */}
+          </div>
+        )}
+        <br />
+        <button className="bg-code-green">投稿する</button>
+      </form>
+    </div>
+  )
+}

--- a/src/pages/newUser/profile.tsx
+++ b/src/pages/newUser/profile.tsx
@@ -1,0 +1,197 @@
+import { doc, getDoc, updateDoc } from 'firebase/firestore'
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { isLoginState, modal, modalAction, uidState } from '../../atoms'
+import { db, storage } from '../../firebaseConfig'
+import { games, languages, sports, watching } from '../../languagesAndHobbies'
+
+export default function NewUserProfile() {
+  const router = useRouter()
+
+  const isLogin = useRecoilValue(isLoginState)
+  const uid = useRecoilValue(uidState)
+  const setOpen = useSetRecoilState(modal)
+  const setAction = useSetRecoilState(modalAction)
+
+  useEffect(() => {
+    if (isLogin === false) {
+      router.push('/')
+    }
+    /* eslint-disable-next-line */
+  }, [isLogin])
+
+  const [userName, setUserName] = useState('')
+  const [userEmail, setUserEmail] = useState('')
+  const [userImage, setUserImage] = useState('')
+  const [userLanguages, setUserLanguages] = useState(['None'])
+  const [userHobbies, setUserHobbies] = useState(['None'])
+
+  useEffect(() => {
+    const getUserProfile = async () => {
+      const userRef = doc(db, 'users', uid)
+      const userSnap = await getDoc(userRef)
+
+      // userEmail !== userSnap.data().email は、useStateによる無限ループを防ぐために
+      if (userSnap.exists() && userEmail !== userSnap.data().email) {
+        setUserName(userSnap.data().name)
+        setUserEmail(userSnap.data().email)
+        setUserImage(userSnap.data().image)
+        setUserLanguages(userSnap.data().languages)
+        setUserHobbies(userSnap.data().hobbies)
+      }
+
+      // firestoreから取ってきた情報をチェックボックスに反映させる
+      for (let i = 0; i < userLanguages.length; i++) {
+        if (userLanguages.length !== 1 || userLanguages[0] !== 'None') {
+          const languageCheckbox = document.getElementById(userLanguages[i]) as HTMLInputElement
+          languageCheckbox.checked = true
+        }
+      }
+      for (let i = 0; i < userHobbies.length; i++) {
+        if (userHobbies.length !== 1 || userHobbies[0] !== 'None') {
+          const hobbyCheckbox = document.getElementById(userHobbies[i]) as HTMLInputElement
+          hobbyCheckbox.checked = true
+        }
+      }
+    }
+    getUserProfile()
+  }, [uid, userEmail, userHobbies, userLanguages])
+
+  const languageCheckboxClick = (e: any) => {
+    if (e.target.checked === true) {
+      if (userLanguages[0] === 'None') {
+        setUserLanguages([e.target.id])
+      } else {
+        setUserLanguages([...userLanguages, e.target.id])
+      }
+    } else {
+      const newFilteringLanguages = userLanguages.filter((language) => !language.match(e.target.id))
+      if (newFilteringLanguages.length !== 0) {
+        setUserLanguages(newFilteringLanguages)
+      } else {
+        setUserLanguages(['None'])
+      }
+    }
+  }
+
+  const hobbyCheckboxClick = (e: any) => {
+    if (e.target.checked === true) {
+      if (userHobbies[0] === 'None') {
+        setUserHobbies([e.target.id])
+      } else {
+        setUserHobbies([...userHobbies, e.target.id])
+      }
+    } else {
+      const newFilteringHobbies = userHobbies.filter((hobby) => !hobby.match(e.target.id))
+      if (newFilteringHobbies.length !== 0) {
+        setUserHobbies(newFilteringHobbies)
+      } else {
+        setUserHobbies(['None'])
+      }
+    }
+  }
+
+  const clickEditDone = async () => {
+    const image = document.getElementById('image') as HTMLInputElement
+    if (image.value !== '') {
+      await uploadBytes(ref(storage, `userImages/${uid}`), image.files[0])
+      const pathReference = ref(storage, `userImages/${uid}`)
+      let imageUrl = ''
+      await getDownloadURL(pathReference).then((url) => {
+        imageUrl = url
+        setUserImage(url)
+      })
+      await updateDoc(doc(db, 'users', uid), {
+        name: userName,
+        image: imageUrl,
+        languages: userLanguages,
+        hobbies: userHobbies
+      })
+    } else {
+      await updateDoc(doc(db, 'users', uid), {
+        name: userName,
+        languages: userLanguages,
+        hobbies: userHobbies
+      })
+    }
+    router.push('/newUser/post')
+    setOpen(true)
+    setAction('プロフィールの登録')
+  }
+
+  if (userEmail !== '') {
+    return (
+      <div>
+        <p>プロフィールを登録しましょう</p>
+        <br />
+        <p>ユーザー名</p>
+        <input value={userName} onChange={(e: any) => setUserName(e.target.value)} />
+        <br />
+        <br />
+        {/* eslint-disable-next-line */}
+        <img src={userImage} alt="現在のプロフィール画像" className="w-[100px]" />
+        <br />
+        <input id="image" type="file" />
+        <br />
+        <br />
+        <p>プログラミング言語</p>
+        <div className="flex">
+          {languages.map((language: string, index: number) => (
+            <div key={index} className="flex">
+              <input
+                type="checkbox"
+                className="h-[16px] w-[16px] m-auto"
+                id={language}
+                onChange={(e: any) => languageCheckboxClick(e)}
+              />
+              <p className="code-blue mr-[10px]">{language},</p>
+            </div>
+          ))}
+        </div>
+        <br />
+        <p>趣味</p>
+        <div className="flex">
+          {games.map((game: string, index: number) => (
+            <div key={index} className="flex">
+              <input
+                type="checkbox"
+                className="h-[16px] w-[16px] m-auto"
+                id={game}
+                onChange={(e: any) => hobbyCheckboxClick(e)}
+              />
+              <p className="code-blue mr-[10px]">{game},</p>
+            </div>
+          ))}
+          {sports.map((sport: string, index: number) => (
+            <div key={index} className="flex">
+              <input
+                type="checkbox"
+                className="h-[16px] w-[16px] m-auto"
+                id={sport}
+                onChange={(e: any) => hobbyCheckboxClick(e)}
+              />
+              <p className="code-blue mr-[10px]">{sport},</p>
+            </div>
+          ))}
+          {watching.map((watch: string, index: number) => (
+            <div key={index} className="flex">
+              <input
+                type="checkbox"
+                className="h-[16px] w-[16px] m-auto"
+                id={watch}
+                onChange={(e: any) => hobbyCheckboxClick(e)}
+              />
+              <p className="code-blue mr-[10px]">{watch},</p>
+            </div>
+          ))}
+        </div>
+        <br />
+        <button onClick={clickEditDone}>登録完了</button>
+      </div>
+    )
+  } else {
+    return <p>読み込み中です</p>
+  }
+}

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -87,7 +87,9 @@ export default function SignUp() {
       setIsLogin(true)
       setUid(uid)
       await sendEmailVerification(auth.currentUser).then(() => {
-        // メールアドレス確認メールを送信した旨のポップアップを出す
+        router.push('/checkMail')
+        setOpen(true)
+        setAction('新規登録')
       })
     }
 
@@ -95,9 +97,6 @@ export default function SignUp() {
     createUserWithEmailAndPassword(auth, email, password)
       .then((userCredential) => {
         setUserFireStore(userCredential.user.uid)
-        router.push('/')
-        setOpen(true)
-        setAction('新規登録')
       })
       .catch((error) => {
         const errorCode = error.code


### PR DESCRIPTION
## IssueのURL
closes #49

## 対応内容・対応背景・妥協点
新規登録後にプロフィール情報と新規投稿への動線を作る

## やったこと
新規登録後にメールアドレスを確認させるように
メールアドレスを確認していないとログイン時にメールアドレス確認ページに飛ぶように
メールアドレスを確認後、プロフィール登録と新規投稿をするよう動線を作成

## UI before / after
![スクリーンショット 2022-07-22 13 07 02](https://user-images.githubusercontent.com/28186588/180360430-da19418e-68af-4cf4-9a56-6cc3f9cf375d.png)