### PR TITLE
ユーザープロフィールに連絡先を追加

### DIFF
--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -29,6 +29,7 @@ export default function UserProfile(props) {
   const [userImage, setUserImage] = useState('')
   const [userLanguages, setUserLanguages] = useState(['None'])
   const [userHobbies, setUserHobbies] = useState(['None'])
+  const [userContact, setUserContact] = useState('')
   const [userPosts, setUserPosts] = useState([{ id: '', title: '', content: '', image: '' }])
   const [userPostNum, setUserPostNum] = useState(0)
   const [message, setMessage] = useState('')
@@ -48,6 +49,7 @@ export default function UserProfile(props) {
           setUserImage(userSnap.data().image)
           setUserLanguages(userSnap.data().languages)
           setUserHobbies(userSnap.data().hobbies)
+          setUserContact(userSnap.data().contact)
           setUserPosts(userSnap.data().posts)
           setUserPostNum(userSnap.data().postNum)
         }
@@ -85,6 +87,7 @@ export default function UserProfile(props) {
         <p>メールアドレス: {userEmail}</p>
         <p>プログラミング言語: {userLanguages}</p>
         <p>趣味: {userHobbies}</p>
+        <p>コンタクト: {userContact}</p>
         <br />
         {page === 'myProfile' && (
           <div>

--- a/src/components/UserProfileEdit .tsx
+++ b/src/components/UserProfileEdit .tsx
@@ -31,6 +31,7 @@ export default function UserProfileEdit(props) {
   const [userImage, setUserImage] = useState('')
   const [userLanguages, setUserLanguages] = useState(['None'])
   const [userHobbies, setUserHobbies] = useState(['None'])
+  const [userContact, setUserContact] = useState('')
 
   useEffect(() => {
     const getUserProfile = async () => {
@@ -44,6 +45,7 @@ export default function UserProfileEdit(props) {
         setUserImage(userSnap.data().image)
         setUserLanguages(userSnap.data().languages)
         setUserHobbies(userSnap.data().hobbies)
+        setUserContact(userSnap.data().contact)
       }
 
       // firestoreから取ってきた情報をチェックボックスに反映させる
@@ -111,13 +113,15 @@ export default function UserProfileEdit(props) {
         name: userName,
         image: imageUrl,
         languages: userLanguages,
-        hobbies: userHobbies
+        hobbies: userHobbies,
+        contact: userContact
       })
     } else {
       await updateDoc(doc(db, 'users', uid), {
         name: userName,
         languages: userLanguages,
-        hobbies: userHobbies
+        hobbies: userHobbies,
+        contact: userContact
       })
     }
     if (page === 'notFirstTime') {
@@ -138,6 +142,10 @@ export default function UserProfileEdit(props) {
         <br />
         <p>ユーザー名</p>
         <input value={userName} onChange={(e: any) => setUserName(e.target.value)} />
+        <br />
+        <br />
+        <p>連絡先</p>
+        <input value={userContact} onChange={(e: any) => setUserContact(e.target.value)} />
         <br />
         <br />
         {/* eslint-disable-next-line */}

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -13,19 +13,30 @@ export default function PostsId() {
   const uid = useRecoilValue(uidState)
 
   const [post, setPost] = useState({ poster: '', title: '', content: '', image: '' })
-
+  const [user, setUser] = useState({
+    name: '',
+    image: '',
+    languages: [],
+    hobbies: [],
+    contact: ''
+  })
   useEffect(() => {
     const getPost = async () => {
       const postRef = doc(db, 'posts', postId)
       const postSnap = await getDoc(postRef)
       if (postSnap.exists()) {
         setPost(postSnap.data())
+        const userRef = doc(db, 'users', postSnap.data().poster)
+        const userSnap = await getDoc(userRef)
+        if (userSnap.exists()) {
+          setUser(userSnap.data())
+        }
       }
     }
     getPost()
   }, [postId])
 
-  if (post.poster !== '') {
+  if (user.image !== '') {
     return (
       <div>
         <p>投稿詳細ページ</p>
@@ -41,6 +52,15 @@ export default function PostsId() {
             <p>投稿編集ページへ</p>
           </Link>
         )}
+        <br />
+        <br />
+        <p>投稿ユーザー</p>
+        <p>{user.name}</p>
+        {/* eslint-disable-next-line */}
+        <img src={user.image} alt="プロフィール画像" className="w-[100px]" />
+        <p>{user.languages}</p>
+        <p>{user.hobbies}</p>
+        <p>{user.contact}</p>
       </div>
     )
   } else {


### PR DESCRIPTION
## IssueのURL
closes #57

## 対応内容・対応背景・妥協点
ユーザープロフィールに連絡先を追加

## やったこと
ユーザープロフィールに連絡先を追加
投稿詳細ページにも連絡先を閲覧できるように

## UI before / after
![スクリーンショット 2022-07-22 20 08 11](https://user-images.githubusercontent.com/28186588/180427021-e3bb6ca8-9b73-48a4-9090-5518a990e738.png)