### PR TITLE
新規登録後にプロフィールページに遷移すると出るエラーを解決

### DIFF
--- a/src/components/LoginSignUp.tsx
+++ b/src/components/LoginSignUp.tsx
@@ -141,6 +141,7 @@ export default function LoginSignUp(props) {
           languages: ['None'],
           name: userName,
           email: email,
+          profile: '',
           image:
             'https://firebasestorage.googleapis.com/v0/b/code-friend.appspot.com/o/userImages%2Finit.jpg?alt=media&token=69a50ddd-5912-4415-91cb-1cdb1fdf6d3f',
           postNum: 0,

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -106,8 +106,10 @@ export default function UserProfile(props) {
                 <p className="mb-[4px]">プロフィール文</p>
                 <div className="bg-zinc-700 w-[100%] rounded">
                   <div className="p-[10px]">
-                    {userProfile.split('\n').map((sentence) => (
-                      <p className="text-code-blue">{sentence}</p>
+                    {userProfile.split('\n').map((sentence: string, index: number) => (
+                      <p className="text-code-blue" key={index}>
+                        {sentence}
+                      </p>
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
## IssueのURL
closes #70
## 対応内容・対応背景・妥協点
新規登録後にプロフィールページに遷移すると出るエラーを解決
## やったこと
新規登録時にuserにprofileフィールドを追加
